### PR TITLE
fix for mariadb headers

### DIFF
--- a/src/node/blockchain_query.h
+++ b/src/node/blockchain_query.h
@@ -107,38 +107,39 @@ int create_new_block( struct packet *block, MYSQL *dbc) {
     long prev_block_hash_length = 128;
 
     MYSQL_BIND param[5];
-    param[0].buffer_type = MYSQL_TYPE_VARCHAR;
+    param[0].buffer_type = MYSQL_TYPE_STRING;
     param[0].buffer = block->timestamp;
     param[0].is_unsigned = 0;
-    param[0].is_null = 0;
+    param[0].is_null = (my_bool)0;
     param[0].length = &timestamp_length;
 
-    param[1].buffer_type = MYSQL_TYPE_VARCHAR;
+    param[1].buffer_type = MYSQL_TYPE_STRING;
     param[1].buffer = block->data_blob;
     param[1].is_unsigned = 0;
-    param[1].is_null = 0;
+    param[1].is_null = (my_bool)0;
     param[1].length = &data_blob_length;
 
-    param[2].buffer_type = MYSQL_TYPE_VARCHAR;
+    param[2].buffer_type = MYSQL_TYPE_STRING;
     param[2].buffer = block->receiver_address;
     param[2].is_unsigned = 0;
-    param[2].is_null = 0;
+    param[2].is_null = (my_bool)0;
     param[2].length = &receiver_address_length;
 
-    param[3].buffer_type = MYSQL_TYPE_VARCHAR;
+    param[3].buffer_type = MYSQL_TYPE_STRING;
     param[3].buffer = block->sender_address;
     param[3].is_unsigned = 0;
-    param[3].is_null = 0;
+    param[3].is_null = (my_bool)0;
     param[3].length = &sender_address_length;
 
-    param[4].buffer_type = MYSQL_TYPE_VARCHAR;
+    param[4].buffer_type = MYSQL_TYPE_STRING;
     param[4].buffer = prev_block_hash;
     param[4].is_unsigned = 0;
-    param[4].is_null = 0;
+    param[4].is_null = (my_bool)0;
     param[4].length = &prev_block_hash_length;
 
+    printf("TEST\n");
     mysql_prepared_query( query_string, param, dbc);
-
+    printf("TEST\n");
     char *block_as_packet = compile_to_packet_buffer(block);
     notify_ticker_subscriber(block->receiver_address, block_as_packet);
 

--- a/src/node/mysql_wrapper.h
+++ b/src/node/mysql_wrapper.h
@@ -25,24 +25,30 @@ MYSQL_STMT* mysql_prepared_query(char *query_string, MYSQL_BIND* param, MYSQL *d
     // Allocate a statement handle
     stmt = mysql_stmt_init(dbc);
     if(stmt == NULL) {
+        printf("%s\n", mysql_error(dbc));
+        printf("1%s\n", mysql_stmt_error(stmt));
         printf("Unable to create new session: Could not init statement handle\n");
     }
 
     // Init
     if(mysql_stmt_prepare(stmt, query_string, strlen(query_string)) != 0) {
         printf("%s\n", mysql_error(dbc));
+        printf("2%s\n", mysql_stmt_error(stmt));
         printf("Unable to create new session: Could not prepare statement\n");
     }
 
     // Bind param structure to statement
     if(mysql_stmt_bind_param(stmt, param) != 0) {
+        printf("%s\n", mysql_error(dbc));
+        printf("3%s\n", mysql_stmt_error(stmt));
         printf("Unable to create new session: Could not bind parameters\n");
     }
 
     // Execute prepared statement
     if(mysql_stmt_execute(stmt) != 0) {
+        printf("%s\n", mysql_error(dbc));
         printf("Unable to create new session: Could not execute statement\n");
-        printf("%s\n", mysql_stmt_error(stmt));
+        printf("4%s\n", mysql_stmt_error(stmt));
     }
 
     //mysql_stmt_close(stmt);


### PR DESCRIPTION
fix for mariadb headers (using Arch instead of Ubuntu, thus different headers). MariaDB decided that VARCHAR  is not good enough, so I use STRING now... whatever